### PR TITLE
Add button action trait to watch.json

### DIFF
--- a/data/devices/watch.json
+++ b/data/devices/watch.json
@@ -404,6 +404,7 @@
             }
         ],
         "traits": [
+            "button.action",
             "display.always-on"
         ],
         "internal_names": ["N230AP"],


### PR DESCRIPTION
Action button is missing from Apple Watch Ultra 3 (it's there in 1 and 2)