### PR TITLE
Update iPhone 17e release year to 2026

### DIFF
--- a/data/devices/iphone.json
+++ b/data/devices/iphone.json
@@ -1410,7 +1410,7 @@
     },
     {
         "name": "iPhone 17e",
-        "year": 2025,
+        "year": 2026,
         "gen": 19,
         "family": {
             "$ref": "../family.json#/iphone"


### PR DESCRIPTION
Probably a typo, but this was just released (not even technically available yet so definitely not 2025).